### PR TITLE
Fix error when message contains NUL bytes

### DIFF
--- a/ext/iec16022ecc200.c
+++ b/ext/iec16022ecc200.c
@@ -778,13 +778,12 @@ encmake (int l, unsigned char *s, int *lenp, char exact)
    return encoding;
 }
 
-void iec16022init(int *Wptr, int *Hptr, const char *barcode)
+void iec16022init(int *Wptr, int *Hptr, int barcode_length)
 {
-	if(Wptr == NULL || Hptr == NULL || barcode == NULL) return;
+	if(Wptr == NULL || Hptr == NULL) return;
 	
-	int barcodelen = strlen(barcode) + 1;
 	struct ecc200matrix_s *matrix;
-	for (matrix = ecc200matrix; matrix->bytes < barcodelen; matrix++);
+	for (matrix = ecc200matrix; matrix->bytes <= barcode_length; matrix++);
 	*Wptr = matrix->W;
 	*Hptr = matrix->H;	
 }

--- a/ext/semacode.c
+++ b/ext/semacode.c
@@ -25,14 +25,9 @@ structure is consulted for any operations, such as to get the
 semacode dimensions. It deallocates any previous data before 
 generating a new encoding.
 
-Due to a bug in the underlying encoder, we do two things
-
- * append a space character before encoding, to get around
-   an off by one error lurking in the C code
-   
- * manually select the best barcode dimensions, to avoid
-   an encoder bug where sometimes no suitable encoding would
-   be found
+Due to a bug in the underlying encoder, we manually select the best barcode
+dimensions to avoid an encoder bug where sometimes no suitable encoding
+would be found
 
 */
 semacode_t* 

--- a/ext/semacode.c
+++ b/ext/semacode.c
@@ -58,7 +58,7 @@ encode_string(semacode_t *semacode, int message_length, char *message)
   message_length++;
   
   // choose the best grid that will hold our message
-  iec16022init(&semacode->width, &semacode->height, message);
+  iec16022init(&semacode->width, &semacode->height, message_length);
   
   // encode the actual data
   semacode->data = (char *) iec16022ecc200(

--- a/ext/semacode.c
+++ b/ext/semacode.c
@@ -53,10 +53,6 @@ encode_string(semacode_t *semacode, int message_length, char *message)
         
   bzero(semacode, sizeof(semacode_t));
   
-  // work around encoding bug by appending an extra character.
-  strcat(message, " ");
-  message_length++;
-  
   // choose the best grid that will hold our message
   iec16022init(&semacode->width, &semacode->height, message_length);
   


### PR DESCRIPTION
strlen stops at the first NUL byte which breaks getting a proper grid
when the message contains any of them. The message length is known at
this point and can be passed to iec16022init instead of the message
pointer.

Edit: I now also removed the workaround that appended a blank to every input string. The `strcat` method also can't handle NUL bytes and I couldn't find a use case where this sort of fiddling was necessary in the first place.